### PR TITLE
sync vip configmap

### DIFF
--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"flag"
+
 	"github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -18,7 +19,7 @@ func NewOptions() *Options {
 			Encoder:         nil,
 			DestWritter:     nil,
 			Level:           zapcore.InfoLevel,
-			StacktraceLevel: nil,
+			StacktraceLevel: zapcore.PanicLevel,
 			ZapOpts:         nil,
 		}}
 }

--- a/pkg/speaker/vip/keepalived.go
+++ b/pkg/speaker/vip/keepalived.go
@@ -3,6 +3,7 @@ package vip
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -18,63 +19,101 @@ import (
 )
 
 type KeepAlived struct {
-	log       logr.Logger
-	clientset *clientset.Clientset
-	cm        *corev1.ConfigMap
-	conf      *KeepAlivedConfig
+	log    logr.Logger
+	client *clientset.Clientset
+	data   map[string]string
+	conf   *KeepAlivedConfig
 }
 
 type KeepAlivedConfig struct {
 	Args []string
 }
 
-func (k *KeepAlived) SetBalancer(configMap string, nexthops []corev1.Node) error {
-	ip := strings.SplitN(configMap, ":", 2)
-	k.cm = &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ConfigMap",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      constant.OpenELBVipConfigMap,
-			Namespace: util.EnvNamespace(),
-		},
-		Data: map[string]string{
-			ip[0]: ip[1],
-		},
-	}
-	k.log.Info(fmt.Sprintf("cm %s", k.cm.String()))
-	var err error
-	if oldCm, err := k.clientset.CoreV1().ConfigMaps(k.cm.ObjectMeta.Namespace).Get(context.TODO(), k.cm.ObjectMeta.Name, metav1.GetOptions{}); errors.IsNotFound(err) {
-		k.cm, err = k.clientset.CoreV1().ConfigMaps(k.cm.ObjectMeta.Namespace).Create(context.TODO(), k.cm, metav1.CreateOptions{})
-		k.log.Info(fmt.Sprintf("create cm %s", k.cm.ObjectMeta.Name))
-		if err != nil {
-			k.log.Error(err, "create cm error")
-		}
-	} else {
-		for oldk, oldv := range oldCm.Data {
-			if _, ok := k.cm.Data[oldk]; !ok {
-				k.cm.Data[oldk] = oldv
+func (k *KeepAlived) SetBalancer(vip string, _ []corev1.Node) error {
+	ip := strings.SplitN(vip, ":", 2)
+
+	if svc, ok := k.data[ip[0]]; ok {
+		//TODO: support proxy: https://github.com/aledbf/kube-keepalived-vip#proxy-protocol-mode
+		svcArray := strings.Split(svc, ";")
+		exist := false
+		for _, s := range svcArray {
+			if s == ip[1] {
+				exist = true
+				break
 			}
 		}
-		k.cm, err = k.clientset.CoreV1().ConfigMaps(k.cm.Namespace).Update(context.TODO(), k.cm, metav1.UpdateOptions{})
+		if !exist {
+			k.data[ip[0]] = svc + ";" + ip[1]
+		}
+	} else {
+		k.data[ip[0]] = ip[1]
 	}
 
-	return err
+	return k.updateConfigMap()
 }
 
-func (k *KeepAlived) DelBalancer(configMap string) error {
-	var err error
-	if _, err = k.clientset.CoreV1().ConfigMaps(k.cm.ObjectMeta.Namespace).Get(context.TODO(), k.cm.ObjectMeta.Name, metav1.GetOptions{}); err == nil {
-		ip := strings.SplitN(configMap, ":", 2)
-		delete(k.cm.Data, ip[0])
-		k.cm, err = k.clientset.CoreV1().ConfigMaps(k.cm.ObjectMeta.Namespace).Update(context.TODO(), k.cm, metav1.UpdateOptions{})
+func (k *KeepAlived) DelBalancer(vip string) error {
+	ip := strings.SplitN(vip, ":", 2)
+	if len(ip) == 1 {
+		delete(k.data, ip[0])
+		return k.updateConfigMap()
 	}
+
+	if svc, ok := k.data[ip[0]]; ok {
+		svcArray := strings.Split(svc, ";")
+		if len(svcArray) == 1 {
+			delete(k.data, ip[0])
+		} else {
+			for i, s := range svcArray {
+				if s == ip[1] {
+					svcArray = append(svcArray[:i], svcArray[i+1:]...)
+					break
+				}
+			}
+			k.data[ip[0]] = strings.Join(svcArray, ";")
+		}
+	}
+
+	return k.updateConfigMap()
+}
+
+func (k *KeepAlived) updateConfigMap() error {
+	ctx := context.Background()
+	cm, err := k.client.CoreV1().ConfigMaps(util.EnvNamespace()).Get(ctx, constant.OpenELBVipConfigMap, metav1.GetOptions{})
+	if err == nil {
+		if reflect.DeepEqual(cm.Data, k.data) {
+			return nil
+		}
+
+		cm.Data = k.data
+		_, err = k.client.CoreV1().ConfigMaps(util.EnvNamespace()).Update(ctx, cm, metav1.UpdateOptions{})
+		return err
+	}
+
+	if errors.IsNotFound(err) {
+		cm = &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constant.OpenELBVipConfigMap,
+				Namespace: util.EnvNamespace(),
+			},
+			Data: k.data,
+		}
+
+		k.log.Info(fmt.Sprintf("not found configmap:%s, so create it", cm.Name))
+		_, err = k.client.CoreV1().ConfigMaps(cm.Namespace).Create(ctx, cm, metav1.CreateOptions{})
+		return err
+	}
+
+	k.log.Error(err, fmt.Sprintf("get configmap:%s error", cm.Name))
 	return err
 }
 
 func (k *KeepAlived) Start(stopCh <-chan struct{}) error {
-	dsClient := k.clientset.AppsV1().DaemonSets(util.EnvNamespace())
+	dsClient := k.client.AppsV1().DaemonSets(util.EnvNamespace())
 	ds, err := dsClient.Get(context.TODO(), constant.OpenELBVipName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -90,26 +129,51 @@ func (k *KeepAlived) Start(stopCh <-chan struct{}) error {
 		}
 	}
 
+	cmClient := k.client.CoreV1().ConfigMaps(util.EnvNamespace())
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constant.OpenELBVipConfigMap,
+			Namespace: util.EnvNamespace(),
+		},
+	}
+	k.log.Info(fmt.Sprintf("create ConfigMap %s", cm.Name))
+	_, err = cmClient.Create(context.TODO(), cm, metav1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		k.log.Error(err, fmt.Sprintf("create cm:%s error", cm.Name))
+		return err
+	}
+
 	go func() {
 		select {
 		case <-stopCh:
 			deletePolicy := metav1.DeletePropagationForeground
-			if err = dsClient.Delete(context.TODO(), ds.Name, metav1.DeleteOptions{
+			deleteOpt := metav1.DeleteOptions{
 				PropagationPolicy: &deletePolicy,
-			}); err != nil {
+			}
+			if err = dsClient.Delete(context.TODO(), ds.Name, deleteOpt); err != nil {
 				k.log.Error(err, "keepalived daemonSet delete error")
 			}
+
+			if err = cmClient.Delete(context.TODO(), cm.Name, deleteOpt); err != nil {
+				k.log.Error(err, "keepalived configMap delete error")
+			}
+
+			return
 		}
 	}()
 
-	return err
+	return nil
 }
 
 // User can config Keepalived by ConfigMap to specify the images
 // If the ConfigMap exists and the configuration is set, use it,
 // 	otherwise, use the default image got from constants.
 func (k *KeepAlived) getConfig() (*corev1.ConfigMap, error) {
-	return k.clientset.CoreV1().ConfigMaps(util.EnvNamespace()).
+	return k.client.CoreV1().ConfigMaps(util.EnvNamespace()).
 		Get(context.Background(), constant.OpenELBImagesConfigMap, metav1.GetOptions{})
 }
 
@@ -217,8 +281,9 @@ var _ speaker.Speaker = &KeepAlived{}
 
 func NewKeepAlived(client *clientset.Clientset, conf *KeepAlivedConfig) *KeepAlived {
 	return &KeepAlived{
-		log:       ctrl.Log.WithName("keepalived"),
-		clientset: client,
-		conf:      conf,
+		log:    ctrl.Log.WithName("keepalived"),
+		client: client,
+		conf:   conf,
+		data:   map[string]string{},
 	}
 }


### PR DESCRIPTION
Signed-off-by: renyunkang <renyunkang@kubesphere.io>


## Description

**What type of PR is this ?:**

<!-- Thanks for your contribution! Describe your changes in a few sentences. Try to include discussion of tradeoffs or alternatives you considered when writing this code. -->
1. Using vip mode will create a configmap in advance to avoid finding the corresponding configmap all the time
2. Support multiple services using the same ip address in vip mode
3. Delete the loadbalancer record when deleting eip

![image](https://user-images.githubusercontent.com/33660223/183840510-7cae0219-34d8-4486-8766-2eaaa5e0456f.png)

#271 
