### PR TITLE
add validation for afisafi config when addpaths is set in bgppeer

### DIFF
--- a/pkg/speaker/bgp/peers.go
+++ b/pkg/speaker/bgp/peers.go
@@ -125,6 +125,19 @@ func (b *Bgp) HandleBgpPeer(neighbor *bgpapi.BgpPeer, delete bool) error {
 				},
 			},
 		})
+	} else {
+		for i := 0; i < len(neighbor.Spec.AfiSafis); i++ {
+			if neighbor.Spec.AfiSafis[i].Config == nil {
+				ip := net.ParseIP(neighbor.Spec.Conf.NeighborAddress)
+				if ip == nil {
+					return fmt.Errorf("field Spec.Conf.NeighborAddress invalid")
+				}
+				neighbor.Spec.AfiSafis[i].Config = &bgpapi.AfiSafiConfig{
+					Family:  defaultFamily(ip),
+					Enabled: true,
+				}
+			}	
+		}
 	}
 
 	request, e := neighbor.Spec.ToGoBgpPeer()


### PR DESCRIPTION
Signed-off-by: Anurag Pathak <anuragpathak911@gmail.com>


## Description

It sets a default value for AfiSafi Config in BGPPeer in case AfiSafi Addpaths is set but not AfiSafi Config.

<!-- Thanks for your contribution! Describe your changes in a few sentences. Try to include discussion of tradeoffs or alternatives you considered when writing this code. -->

## Related links:

<!-- If you have links to [issues](https://github.com/openelb/openelb/issues) etc, link them here. -->
