### PR TITLE
chore(deploy): 🔧 Tolerate node-role.kubernetes.io/control-plane:NoSch…

### DIFF
--- a/config/workloads/manager.yaml
+++ b/config/workloads/manager.yaml
@@ -36,6 +36,8 @@ spec:
         # cloud controller manages should be able to run on masters
         - key: "node-role.kubernetes.io/master"
           effect: NoSchedule
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: openelb-admission

--- a/deploy/openelb.yaml
+++ b/deploy/openelb.yaml
@@ -1230,6 +1230,8 @@ spec:
         operator: Exists
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       volumes:
       - name: webhook-cert
         secret:


### PR DESCRIPTION
The Kubernetes project is moving away from offensive wording and as part of this KEP-2067 was accepted to replace the 
`node-role.kubernetes.io/master:NoSchedule` taint with 
`node-role.kubernetes.io/control-plane:NoSchedule`.

To be compatible with clusters that already use the new taint this pull request adds an additional toleration for it.

Signed-off-by: t106362512 <t106362512@gmail.com>

## Description

**What type of PR is this ?:**

- /bug

## Related links:

- #312 
