### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/config/workloads/cert.yaml
+++ b/config/workloads/cert.yaml
@@ -65,7 +65,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -94,7 +94,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/deploy/openelb.yaml
+++ b/deploy/openelb.yaml
@@ -1263,8 +1263,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        # If you cannot access "k8s.gcr.io/ingress-nginx/kube-webhook-certgen", you can replace it with "kubespheredev/kube-webhook-certgen"
-        image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+        # If you cannot access "registry.k8s.io/ingress-nginx/kube-webhook-certgen", you can replace it with "kubespheredev/kube-webhook-certgen"
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
         imagePullPolicy: IfNotPresent
         name: create
       restartPolicy: OnFailure
@@ -1296,8 +1296,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        # If you cannot access "k8s.gcr.io/ingress-nginx/kube-webhook-certgen", you can replace it with "kubespheredev/kube-webhook-certgen"
-        image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+        # If you cannot access "registry.k8s.io/ingress-nginx/kube-webhook-certgen", you can replace it with "kubespheredev/kube-webhook-certgen"
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
         imagePullPolicy: IfNotPresent
         name: patch
       restartPolicy: OnFailure


### PR DESCRIPTION
## Description

Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.

**What type of PR is this ?:**
/kind chore

<!-- Thanks for your contribution! Describe your changes in a few sentences. Try to include discussion of tradeoffs or alternatives you considered when writing this code. -->

## Related links:

<!-- If you have links to [issues](https://github.com/openelb/openelb/issues) etc, link them here. -->
