### PR TITLE
fix mac address src for lb ip in  arp response when openelb pod restart on another k8s node

### DIFF
--- a/pkg/speaker/layer2/arp.go
+++ b/pkg/speaker/layer2/arp.go
@@ -342,7 +342,7 @@ func (a *arpSpeaker) processRequest() dropReason {
 		a.logger.Info("send gratuitous arp packet in processRequest",
 			"eip", ip, "hwAddr", hwAddr)
 
-		fb, err := generateArp(a.intf.HardwareAddr, op, *hwAddr, ip, ethernet.Broadcast, ip)
+		fb, err = generateArp(a.intf.HardwareAddr, op, *hwAddr, ip, ethernet.Broadcast, ip)
 		if err != nil {
 			a.logger.Error(err, "generate gratuitous arp packet")
 			return dropReasonError

--- a/pkg/speaker/layer2/arp.go
+++ b/pkg/speaker/layer2/arp.go
@@ -340,9 +340,9 @@ func (a *arpSpeaker) processRequest() dropReason {
 	ip := pkt.TargetIP
 	for _, op := range []arp.Operation{arp.OperationRequest, arp.OperationReply} {
 		a.logger.Info("send gratuitous arp packet in processRequest",
-			"eip", ip, "hwAddr", hwAddr)
+			"eip", ip, "hwAddr", a.intf.HardwareAddr)
 
-		fb, err = generateArp(a.intf.HardwareAddr, op, *hwAddr, ip, ethernet.Broadcast, ip)
+		fb, err = generateArp(a.intf.HardwareAddr, op, a.intf.HardwareAddr, ip, ethernet.Broadcast, ip)
 		if err != nil {
 			a.logger.Error(err, "generate gratuitous arp packet")
 			return dropReasonError


### PR DESCRIPTION
## Description

**What type of PR is this ?:**
the first openelb deploy will generate arp item in switch, for example 172.31.249.200 lb ip
<img width="586" alt="01" src="https://github.com/openelb/openelb/assets/10548812/9f06e0c2-6533-464c-8e4d-0c8d24daef28">

when openelb pod restart on another k8s node(fisrt in BAGG52 peer node, restart on XGE2/0/17 peer node)
the arp table source endpoint (from BAGG52 to  XGE2/0/17) in switch will change 
<img width="616" alt="02" src="https://github.com/openelb/openelb/assets/10548812/7631a274-5671-4365-a9a8-4c3ccf945249">

if wen did not update lb ip mac addresses like in this pr.
the will lead network unreach for switch gateway to lb ip
```
ping -vpn-instance N6.1001-MEC 172.31.249.200
```
because the source endpoint not consistency

<!-- Thanks for your contribution! Describe your changes in a few sentences. Try to include discussion of tradeoffs or alternatives you considered when writing this code. -->

## Related links:

<!-- If you have links to [issues](https://github.com/openelb/openelb/issues) etc, link them here. -->
