### PR TITLE
optimize controller recycling ip

### DIFF
--- a/pkg/controllers/ipam/controller.go
+++ b/pkg/controllers/ipam/controller.go
@@ -102,7 +102,7 @@ func (i *EIPController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 	//i.updateMetrics(eip)
-	return ctrl.Result{}, i.Client.Status().Update(ctx, clone)
+	return ctrl.Result{}, i.Status().Update(ctx, clone)
 }
 
 func (i *EIPController) updateEip(ctx context.Context, e *networkv1alpha2.Eip) error {

--- a/pkg/controllers/ipam/ipam_test.go
+++ b/pkg/controllers/ipam/ipam_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -176,7 +177,12 @@ func TestManager_ConstructAllocate(t *testing.T) {
 				},
 				Status: v1.ServiceStatus{},
 			},
-			wantErr: true,
+			wantErr: false,
+			wantRelease: &svcRecord{
+				Key: "default/testsvc",
+				Eip: "eip",
+				IP:  "192.168.1.0",
+			},
 		},
 
 		{
@@ -986,6 +992,7 @@ func TestManager_ConstructAllocate(t *testing.T) {
 			cl.WithScheme(scheme).WithObjects(objs...)
 
 			m := NewManager(cl.Build())
+			m.EventRecorder = &record.FakeRecorder{}
 			request, err := m.ConstructRequest(context.Background(), tt.svc)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Request.ConstructAllocate() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
## Description

**What type of PR is this ?:**

<!-- Thanks for your contribution! Describe your changes in a few sentences. Try to include discussion of tradeoffs or alternatives you considered when writing this code. -->

fix bug:
1. When the EIP pool is deleted, the EIP addresses occupied by the SVC should be released simultaneously.
2. When an EIP is created, unallocated services should immediately check for suitable EIPs and assign IP addresses.
3. Filter out disabled and currently deleting EIPs when assigning IP addresse.

## Related links:

<!-- If you have links to [issues](https://github.com/openelb/openelb/issues) etc, link them here. -->
