### PR TITLE
fix: ipam specify a different IP

### DIFF
--- a/pkg/controllers/ipam/ipam.go
+++ b/pkg/controllers/ipam/ipam.go
@@ -81,7 +81,7 @@ func (i *Manager) assignIPFromEip(allocate *svcRecord, eip *networkv1alpha2.Eip)
 	for addr, svcs := range eip.Status.Used {
 		tmp := strings.Split(svcs, ";")
 		for _, svc := range tmp {
-			if svc == allocate.Key {
+			if svc == allocate.Key && allocate.IP == addr {
 				return addr, nil
 			}
 		}

--- a/pkg/controllers/ipam/ipam_test.go
+++ b/pkg/controllers/ipam/ipam_test.go
@@ -1216,6 +1216,28 @@ func TestManager_AssignIP(t *testing.T) {
 				}(),
 			},
 		},
+		{
+			name:         "Allocation records that already exist but specify a different IP",
+			wantErr:      false,
+			wantAllocate: true,
+			args: args{
+				allocate: &svcRecord{
+					Key: "default/svc",
+					Eip: "eip",
+					IP:  "192.168.1.110",
+				},
+			},
+			fields: fields{
+				eip: func() *networkv1alpha2.Eip {
+					clone := eip.DeepCopy()
+					clone.Status.Usage = 1
+					clone.Status.Used = map[string]string{
+						"192.168.1.100": "default/svc",
+					}
+					return clone
+				}(),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

**What type of PR is this ?:**

<!-- Thanks for your contribution! Describe your changes in a few sentences. Try to include discussion of tradeoffs or alternatives you considered when writing this code. -->

Allocation records that already exist, but the service specifies a different IP, should release the old IP allocation and assign the  specified IP.

## Related links:

<!-- If you have links to [issues](https://github.com/openelb/openelb/issues) etc, link them here. -->

fix #426 
