### PR TITLE
delete a single record instead of the entire instance

### DIFF
--- a/pkg/speaker/vip/keepalived.go
+++ b/pkg/speaker/vip/keepalived.go
@@ -185,13 +185,11 @@ func (k *keepAlived) DelBalancer(vip string) error {
 	}
 	delete(k.vips, vip)
 
-	instance, exist := k.instances[instanceName]
-	if !exist {
+	if _, exist := k.instances[instanceName]; !exist {
 		return nil
 	}
-	delete(k.instances, instanceName)
-	k.idAlloc.Free(instance.RouteID)
 
+	k.cleanRecord(vip, instanceName)
 	if err := k.WriteCfg(); err != nil {
 		klog.Error(err)
 		return err


### PR DESCRIPTION
## Description

**What type of PR is this ?:**

<!-- Thanks for your contribution! Describe your changes in a few sentences. Try to include discussion of tradeoffs or alternatives you considered when writing this code. -->

When using `DelBalancer` in vip mode, a single record should be deleted instead of the entire instance.

## Related links:

<!-- If you have links to [issues](https://github.com/openelb/openelb/issues) etc, link them here. -->
