### PR TITLE
Change the IP prefix in BGP mode

### DIFF
--- a/pkg/speaker/bgp/bgp/path.go
+++ b/pkg/speaker/bgp/bgp/path.go
@@ -137,6 +137,10 @@ func (b *Bgp) ready() error {
 
 func (b *Bgp) setBalancer(ip string, nexthops []string) error {
 	prefix := uint32(32)
+	if net.ParseIP(ip).To4() == nil {
+		prefix = 128
+	}
+
 	err, toAdd, toDelete := b.retriveRoutes(ip, prefix, nexthops)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

**What type of PR is this ?:**
Change the IP prefix so that OpenELB’s BGP mode can support IPv6


## Related links:

