### PR TITLE
eip ranges do not need to be in iface's network segment

### DIFF
--- a/pkg/speaker/layer2/memberlist.go
+++ b/pkg/speaker/layer2/memberlist.go
@@ -156,10 +156,6 @@ func (l *layer2Speaker) ConfigureWithEIP(config speaker.Config, deleted bool) er
 		return err
 	}
 
-	if err := speaker.ValidateInterface(netif, config.IPRange); err != nil {
-		return err
-	}
-
 	if deleted {
 		return l.unregisterAnnouncer(config.Name, netif.Name)
 	}

--- a/pkg/speaker/utils.go
+++ b/pkg/speaker/utils.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/openelb/openelb/pkg/util/iprange"
 	"github.com/vishvananda/netlink"
 )
 
@@ -40,31 +39,4 @@ func ParseInterface(ifaceName string) (iface *net.Interface, err error) {
 	}
 
 	return iface, nil
-}
-
-func ValidateInterface(netif *net.Interface, r iprange.Range) error {
-	addrs, err := netif.Addrs()
-	if err != nil {
-		return err
-	}
-
-	for _, addr := range addrs {
-		ip, cidrnet, err := net.ParseCIDR(addr.String())
-		if err != nil {
-			return err
-		}
-
-		if ip.To4() != nil {
-			if cidrnet.Contains(r.Start()) && cidrnet.Contains(r.End()) {
-				return nil
-			}
-		}
-		if ip.To16() != nil {
-			if cidrnet.Contains(r.Start()) && cidrnet.Contains(r.End()) {
-				return nil
-			}
-		}
-	}
-
-	return fmt.Errorf("%s's ip and the eip[%s] are not in the same network segment", netif.Name, r.String())
 }

--- a/pkg/speaker/vip/keepalived.go
+++ b/pkg/speaker/vip/keepalived.go
@@ -257,10 +257,6 @@ func (k *keepAlived) ConfigureWithEIP(config speaker.Config, deleted bool) error
 	if err != nil || netif == nil {
 		return err
 	}
-	config.Iface = netif.Name
-	if err := speaker.ValidateInterface(netif, config.IPRange); err != nil {
-		return err
-	}
 
 	if deleted {
 		delete(k.configs, config.Name)


### PR DESCRIPTION
## Description

**What type of PR is this ?:**

This PR eliminates the erroneous validation which rejects Eip's which are not in the interface's network segment. 

## Related links:

#456 
