### PR TITLE
Helm Chart: Add support for specifying priorityClassName

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
 - email: kubesphere@gmail.com
   name: KubeSphere
 name: openelb
-version: 0.6.0
+version: 0.6.1
 sources:
   - https://github.com/openelb/openelb
 type: application

--- a/charts/README.md
+++ b/charts/README.md
@@ -97,7 +97,7 @@ The following table lists the configurable parameters of the OpenELB chart and t
 | `speaker.affinity`            | The affinity settings for the openelb-speaker.               |                                   |
 | `speaker.tolerations`         | The tolerations for the openelb-speaker.                     |                                   |
 | `speaker.nodeSelector`        | The node selector for the openelb-speaker                    |                                   |
-| `speaker.priorityClass`       | Priority Class Name for the openelb-controller               |                                   |
+| `speaker.priorityClass`       | Priority Class Name for the openelb-speaker                  |                                   |
 | `customImage.enable`          | Enable or disable the use of custom images.                  | `false`                           |
 | `customImage.forwardImage`    | The custom image for the openelb-forward component.          |                                   |
 | `customImage.proxyImage`      | The custom image for the openelb-proxy component.            |                                   |

--- a/charts/README.md
+++ b/charts/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the OpenELB chart and t
 | `controller.affinity`         | The affinity settings  for the openelb-controller.           |                                   |
 | `controller.tolerations`      | The tolerations for the openelb-controller.                  |                                   |
 | `controller.nodeSelector`     | The node selector for the openelb-controller.                |                                   |
+| `controller.priorityClass`    | Priority Class name for the openelb-controller               |                                   |
 | `speaker.enable`              | Enable or disable the speaker component.                     | `true`                            |
 | `speaker.vip`                 | Enable or disable VIP mode for the speaker.                  | `false`                           |
 | `speaker.layer2`              | Enable or disable Layer2 mode for the speaker.               | `false`                            |
@@ -96,6 +97,7 @@ The following table lists the configurable parameters of the OpenELB chart and t
 | `speaker.affinity`            | The affinity settings for the openelb-speaker.               |                                   |
 | `speaker.tolerations`         | The tolerations for the openelb-speaker.                     |                                   |
 | `speaker.nodeSelector`        | The node selector for the openelb-speaker                    |                                   |
+| `speaker.priorityClass`       | Priority Class Name for the openelb-controller               |                                   |
 | `customImage.enable`          | Enable or disable the use of custom images.                  | `false`                           |
 | `customImage.forwardImage`    | The custom image for the openelb-forward component.          |                                   |
 | `customImage.proxyImage`      | The custom image for the openelb-proxy component.            |                                   |

--- a/charts/templates/openelb-controller.yaml
+++ b/charts/templates/openelb-controller.yaml
@@ -25,6 +25,9 @@ spec:
         {{- include "openelb.controller.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "openelb.controller.serviceAccountName" . }}
+      {{- with .Values.controller.priorityClass }}
+      priorityClassName: {{ . }}
+      {{- end }}
       affinity: {{- toYaml .Values.controller.affinity | nindent 8 }}
       tolerations: {{- toYaml .Values.controller.tolerations | nindent 8 }}
       nodeSelector: {{- toYaml .Values.controller.nodeSelector | nindent 8 }}

--- a/charts/templates/openelb-speaker.yaml
+++ b/charts/templates/openelb-speaker.yaml
@@ -25,6 +25,9 @@ spec:
       tolerations: {{- toYaml .Values.speaker.tolerations | nindent 8 }}
       nodeSelector:
         {{- toYaml .Values.speaker.nodeSelector | nindent 8 }}
+      {{- with .Values.speaker.priorityClass }}
+      priorityClassName: {{ . }}
+      {{- end }}
       serviceAccountName: {{ template "openelb.speaker.serviceAccountName" . }}
       containers:
         - name: openelb-speaker

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -35,6 +35,7 @@ controller:
       key: node-role.kubernetes.io/master
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
+  priorityClass: ""
   # nodeSelector:
   #   node-role.kubernetes.io/control-plane: ""
   # affinity:
@@ -68,6 +69,7 @@ speaker:
     requests:
       cpu: 100m
       memory: 100Mi
+  priorityClass: ""
   # nodeSelector:
   #   kubernetes.io/os: linux
   # affinity:


### PR DESCRIPTION
New feature: Allow pod priorityClassName to be configurable for speaker & controller

See also https://github.com/openelb/openelb/issues/461